### PR TITLE
Add a system design self-review rubric resource

### DIFF
--- a/src/assets/articles/systemDesignInterviewV1Ch14.md
+++ b/src/assets/articles/systemDesignInterviewV1Ch14.md
@@ -181,6 +181,7 @@ CDNs can be used automatically when based on factors like view thresholds, uploa
 Articles:
 
 - The Hello Interview team has a great article walking through <a target="_blank" rel="noopener" href="https://www.cloudflare.com/learning/video/what-is-adaptive-bitrate-streaming/">handling large files</a>
+- Use PracHub's <a target="_blank" rel="noopener" href="https://prachub.com/resources/system-design-interview-rubric-by-level-mid-level-vs-senior-vs-staff">system design interview rubric by level</a> to compare the same design against mid-level, senior, and staff expectations.
 
 Videos:
 


### PR DESCRIPTION
## Summary

- Adds one self-review resource to the article's existing `Other Resources` section.
- Leaves the article's design analysis and current references unchanged.

## Why it may fit

The rubric gives readers a concrete way to compare the same system design against mid-level, senior, and staff expectations after working through the YouTube design exercise.

## Verification

- `git diff --check`
- One file changed, one line added

Disclosure: I founded PracHub and am submitting this small source addition for independent editorial review.